### PR TITLE
auth: tolerate navigation context destroyed during Google OAuth login

### DIFF
--- a/deepseek/auth.py
+++ b/deepseek/auth.py
@@ -98,21 +98,38 @@ _READ_TOKEN_JS = """
 """
 
 
+def _safe_evaluate(page, js: str):
+    """Run page.evaluate, swallowing the benign 'Execution context was destroyed'
+    error that fires when a navigation (e.g. the post-login redirect) happens to
+    land mid-evaluate. Returns None on any such transient failure instead of
+    raising, so callers can just retry on the next poll."""
+    try:
+        return page.evaluate(js)
+    except Exception as e:
+        msg = str(e)
+        if "Execution context was destroyed" in msg or "navigation" in msg.lower():
+            return None
+        raise
+
+
 def _capture_from_context(context, page) -> Optional[Session]:
     """Read token + cookies + UA off a logged-in page, or None if not signed in."""
-    token = page.evaluate(_READ_TOKEN_JS)
+    token = _safe_evaluate(page, _READ_TOKEN_JS)
     if not token:
         return None
     cookies = {c["name"]: c["value"] for c in context.cookies()}
-    ua = page.evaluate("() => navigator.userAgent")
+    ua = _safe_evaluate(page, "() => navigator.userAgent") or ""
     return Session(token=token, cookies=cookies, user_agent=ua, captured_at=time.time())
 
 
 def _wait_for_token(page, timeout: float) -> Optional[str]:
-    """Poll localStorage.userToken until it appears or we time out."""
+    """Poll localStorage.userToken until it appears or we time out. Tolerates
+    transient navigations (e.g. the Google OAuth redirect chain) that briefly
+    destroy the page's JS execution context — those just count as "no token
+    yet" rather than aborting the whole login."""
     deadline = time.time() + timeout
     while time.time() < deadline:
-        token = page.evaluate(_READ_TOKEN_JS)
+        token = _safe_evaluate(page, _READ_TOKEN_JS)
         if token:
             return token
         page.wait_for_timeout(1000)


### PR DESCRIPTION
## Problem:
After signing in with Google, the AWS WAF human-check / OAuth flow redirects the page while login() is polling localStorage.userToken via page.evaluate(...). When the poll happens to fire mid-navigation, Playwright destroys the page's JS execution context and raises:

```
Traceback (most recent call last):

File "<frozen runpy>", line 198, in _run_module_as_main

File "<frozen runpy>", line 88, in _run_code

File "deepseek/auth.py", line 248, in <module>

s = login()

File "deepseek/auth.py", line 174, in login

if not _wait_for_token(page, timeout=300):

~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^

File "deepseek/auth.py", line 115, in _wait_for_token

token = page.evaluate(_READ_TOKEN_JS)

...

playwright._impl._errors.Error: Page.evaluate: Execution context was destroyed, most likely because of a navigation
```

This crashes the whole login flow instead of just retrying on the next poll tick.

## Fix:
Added a _safe_evaluate() wrapper around page.evaluate() that catches the "Execution context was destroyed" / navigation error and returns None instead of raising. _wait_for_token() and _capture_from_context() now use this wrapper, so a token read that races a redirect (e.g. the Google OAuth bounce back to chat.deepseek.com) is simply treated as "no token yet" and retried on the next 1s poll, rather than aborting the script.

## Testing:
Reproduced the crash locally on Windows by signing in via Google. After the fix, python -m deepseek.auth survives the post-Google redirect and completes the login, capturing the token and saving the session as expected.